### PR TITLE
Updated prefix for tables to CB_

### DIFF
--- a/FDMBuilder/FDMTable.py
+++ b/FDMBuilder/FDMTable.py
@@ -13,8 +13,8 @@ warnings.filterwarnings("ignore", category=SyntaxWarning)
 # Set global variables 
 PROJECT = "yhcr-prd-phm-bia-core"
 CLIENT = bigquery.Client(project=PROJECT)
-DEMOGRAPHICS = f"{PROJECT}.CY_STAGING_DATABASE.src_DemoGraphics_MASTER"
-MASTER_PERSON = f"{PROJECT}.CY_FDM_MASTER.person"
+DEMOGRAPHICS = f"{PROJECT}.CB_STAGING_DATABASE.src_DemoGraphics_MASTER"
+MASTER_PERSON = f"{PROJECT}.CB_FDM_MASTER.person"
 
     
 class FDMTable:

--- a/FDMBuilder/build_tutorial_test_tables.py
+++ b/FDMBuilder/build_tutorial_test_tables.py
@@ -6,7 +6,7 @@ from FDMBuilder.testing_helpers import *
 # collect 50 random people from person table
 persons_sql = """
     SELECT person_id, birth_datetime, death_datetime
-    FROM `CY_FDM_MASTER.person`
+    FROM `CB_FDM_MASTER.person`
     LIMIT 50
 """
 persons = CLIENT.query(persons_sql).to_dataframe() 
@@ -14,7 +14,7 @@ persons = CLIENT.query(persons_sql).to_dataframe()
 # collect another 50 random people with a death_datetime from person table
 dead_persons_sql = """
     SELECT person_id, birth_datetime, death_datetime
-    FROM `CY_FDM_MASTER.person`
+    FROM `CB_FDM_MASTER.person`
     WHERE death_datetime IS NOT NULL
     LIMIT 50
 """
@@ -51,15 +51,15 @@ test_table_1 = test_table_1[["person_id", "start_date"]]
 # add some random data
 test_table_1["some_data"] = np.random.choice(range(100000), 100)
 # upload table to gbq
-test_table_1.to_gbq(destination_table="CY_FDM_BUILDER_TESTS.test_table_1",
+test_table_1.to_gbq(destination_table="CB_FDM_BUILDER_TESTS.test_table_1",
                     project_id="yhcr-prd-phm-bia-core",
                     if_exists="replace")
 
 # select random entries from master person table that have a corresponding digest
 persons_2_sql = """
     SELECT demo.digest, person.birth_datetime, person.death_datetime
-    FROM `CY_FDM_MASTER.person` person
-    INNER JOIN `CY_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
+    FROM `CB_FDM_MASTER.person` person
+    INNER JOIN `CB_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
     ON demo.person_id = person.person_id
     WHERE digest IS NOT NULL
     LIMIT 50
@@ -69,8 +69,8 @@ persons_2 = CLIENT.query(persons_2_sql).to_dataframe()
 # corresponding digest
 dead_persons_2_sql = """
     SELECT demo.digest, person.birth_datetime, person.death_datetime
-    FROM `CY_FDM_MASTER.person` person
-    INNER JOIN `CY_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
+    FROM `CB_FDM_MASTER.person` person
+    INNER JOIN `CB_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
     ON demo.person_id = person.person_id
     WHERE digest IS NOT NULL
     AND death_datetime IS NOT NULL
@@ -132,7 +132,7 @@ test_table_2 = test_table_2[["wrong_digest", "start_month", "start_year",
                              "end_month", "end_year"]]
 # create random data column
 test_table_2["some_data"] = np.random.choice(range(100000), 100)
-test_table_2.to_gbq(destination_table="CY_FDM_BUILDER_TESTS.test_table_2",
+test_table_2.to_gbq(destination_table="CB_FDM_BUILDER_TESTS.test_table_2",
                     project_id="yhcr-prd-phm-bia-core",
                     if_exists="replace")
 
@@ -140,8 +140,8 @@ test_table_2.to_gbq(destination_table="CY_FDM_BUILDER_TESTS.test_table_2",
 # for guidance
 persons_3_sql = """
     SELECT demo.EDRN, person.birth_datetime, person.death_datetime
-    FROM `CY_FDM_MASTER.person` person
-    INNER JOIN `CY_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
+    FROM `CB_FDM_MASTER.person` person
+    INNER JOIN `CB_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
     ON demo.person_id = person.person_id
     WHERE EDRN IS NOT NULL
     LIMIT 50
@@ -150,8 +150,8 @@ persons_3 = CLIENT.query(persons_3_sql).to_dataframe()
 
 dead_persons_3_sql = """
     SELECT demo.EDRN, person.birth_datetime, person.death_datetime
-    FROM `CY_FDM_MASTER.person` person
-    INNER JOIN `CY_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
+    FROM `CB_FDM_MASTER.person` person
+    INNER JOIN `CB_STAGING_DATABASE.src_DemoGraphics_MASTER` demo
     ON demo.person_id = person.person_id
     WHERE EDRN IS NOT NULL
     AND death_datetime IS NOT NULL
@@ -201,6 +201,6 @@ test_table_3.drop(["birth_datetime", "death_datetime", "digest",
                    "start_date", "end_date"], 
                   axis=1, 
                   inplace=True)
-test_table_3.to_gbq(destination_table="CY_FDM_BUILDER_TESTS.test_table_3",
+test_table_3.to_gbq(destination_table="CB_FDM_BUILDER_TESTS.test_table_3",
                     project_id="yhcr-prd-phm-bia-core",
                     if_exists="replace")

--- a/FDMBuilder/upload_ss_data_to_bq.R
+++ b/FDMBuilder/upload_ss_data_to_bq.R
@@ -146,8 +146,8 @@ upload_table_to_bq <- function(table_id,
 ###### CHANGE THESE VARIABLES TO SUIT #######
 
 upload_table_id <- "tbl_SRAppointment"
-upload_table_dataset_id <- "CY_FDM_TEST"
-bq_dataset_id <- "CY_SAM_TEST"
+upload_table_dataset_id <- "CB_FDM_TEST"
+bq_dataset_id <- "CB_SAM_TEST"
 upload_batch_size <- 2000000
 
 #############################################

--- a/fdm_builder_tutorials/fdm_builder_basics_tutorial.ipynb
+++ b/fdm_builder_tutorials/fdm_builder_basics_tutorial.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "### !!REPLACE THIS TEXT!! ###\n",
     "\n",
-    "DATASET_ID = \"CY_SAM_TEST\"\n",
+    "DATASET_ID = \"CB_SAM_TEST\"\n",
     "\n",
     "###\n",
     "\n",
@@ -89,7 +89,7 @@
    "source": [
     "As you may have figured out, the above code stores the name of your new dataset in a variable called `DATASET_ID`, and does a quick check to make sure the dataset exists - if it does exist it then clears out any tables already in the dataset, so there's a fresh space to work in. Don't worry too much if this code looks daunting or difficult to understand - you don't need to understand the above to be able to use the `FDMBuilder` tools. All you need to worry about is seeing a message saying `Good to go!` in the cell output above.\n",
     "\n",
-    "We'll also be using a couple of pre-prepared source datasets that can be found in `CY_FDM_BUILDER_TESTS`. Take a quick look in the BigQuery SQL workspace to check you've been given access to the test dataset and that you can see the three test tables, aptly named `test_table_1`,  `test_table_2` and `test_table_3`. If not give me (Sam) a shout. \n",
+    "We'll also be using a couple of pre-prepared source datasets that can be found in `CB_FDM_BUILDER_TESTS`. Take a quick look in the BigQuery SQL workspace to check you've been given access to the test dataset and that you can see the three test tables, aptly named `test_table_1`,  `test_table_2` and `test_table_3`. If not give me (Sam) a shout. \n",
     "\n",
     "## FDM Builder - The basics\n",
     "\n",
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "test_table_1 = FDMTable(\n",
-    "    source_table_id=\"CY_FDM_BUILDER_TESTS.test_table_1\",\n",
+    "    source_table_id=\"CB_FDM_BUILDER_TESTS.test_table_1\",\n",
     "    dataset_id=DATASET_ID\n",
     ")"
    ]
@@ -193,7 +193,7 @@
    "outputs": [],
    "source": [
     "test_table_2 = FDMTable(\n",
-    "    source_table_id=\"CY_FDM_BUILDER_TESTS.test_table_2\",\n",
+    "    source_table_id=\"CB_FDM_BUILDER_TESTS.test_table_2\",\n",
     "    dataset_id=DATASET_ID\n",
     ")\n",
     "test_table_2.build()"

--- a/fdm_builder_tutorials/fdm_builder_extras_tutorial.ipynb
+++ b/fdm_builder_tutorials/fdm_builder_extras_tutorial.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "### !!REPLACE THIS TEXT!! ###\n",
     "\n",
-    "DATASET_ID = \"CY_SAM_TEST\"\n",
+    "DATASET_ID = \"CB_SAM_TEST\"\n",
     "\n",
     "###\n",
     "\n",
@@ -61,7 +61,7 @@
    "source": [
     "%%bigquery\n",
     "SELECT *\n",
-    "FROM `CY_FDM_MASTER.person`\n",
+    "FROM `CB_FDM_MASTER.person`\n",
     "LIMIT 10"
    ]
   },
@@ -84,7 +84,7 @@
    "source": [
     "%%bigquery eg_df\n",
     "SELECT *\n",
-    "FROM `CY_FDM_MASTER.person`\n",
+    "FROM `CB_FDM_MASTER.person`\n",
     "LIMIT 10"
    ]
   },
@@ -128,7 +128,7 @@
    "outputs": [],
    "source": [
     "test_table_3 = FDMTable(\n",
-    "    source_table_id = \"CY_FDM_BUILDER_TESTS.test_table_3\",\n",
+    "    source_table_id = \"CB_FDM_BUILDER_TESTS.test_table_3\",\n",
     "    dataset_id=DATASET_ID\n",
     ")"
    ]
@@ -354,7 +354,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "check_dataset_exists(\"CY_FDM_MASTER\")"
+    "check_dataset_exists(\"CB_FDM_MASTER\")"
    ]
   },
   {
@@ -394,7 +394,7 @@
    "source": [
     "## Example FDM Building Workflow\n",
     "\n",
-    "Righty, we've reached the now much talked about example workflow. In this example, we'll assume we're building an FDM from scratch, using the tables in `CY_FDM_BUILDER_TESTS`. The process will be similar to that of the basics tutorial, but a little more \"programmatic\" and with less navigating backwards and forwards between Jupyter and GCP.\n",
+    "Righty, we've reached the now much talked about example workflow. In this example, we'll assume we're building an FDM from scratch, using the tables in `CB_FDM_BUILDER_TESTS`. The process will be similar to that of the basics tutorial, but a little more \"programmatic\" and with less navigating backwards and forwards between Jupyter and GCP.\n",
     "\n",
     "A quick note - you should expect to see some errors when going through this workflow. Indeed errors are a normal part of programming in any language! The FDM tools have been designed to be (relatively) robust to various missteps, so you should see an informative error message if you something one of the tools doesn't like. At any rate, if you see an error here, don't panic - it's supposed to be there. Just give the error message a quick read (the main message will be at the bottom of the error readout) and continue with the tutorial - it will (hopefully) keep you abreast of what's happening. \n",
     "\n",
@@ -409,7 +409,7 @@
    "outputs": [],
    "source": [
     "test_table_1 = FDMTable(\n",
-    "    source_table_id = \"CY_FDM_BUILDER_TESTS.test_table_1\",\n",
+    "    source_table_id = \"CB_FDM_BUILDER_TESTS.test_table_1\",\n",
     "    dataset_id = DATASET_ID\n",
     ")"
    ]
@@ -490,7 +490,7 @@
    "outputs": [],
    "source": [
     "test_table_2 = FDMTable(\n",
-    "    source_table_id = \"CY_FDM_BUILDER_TESTS.test_table_2\",\n",
+    "    source_table_id = \"CB_FDM_BUILDER_TESTS.test_table_2\",\n",
     "    dataset_id = DATASET_ID\n",
     ")\n",
     "test_table_2.copy_table_to_dataset()\n",
@@ -581,7 +581,7 @@
    "outputs": [],
    "source": [
     "test_table_3 = FDMTable(\n",
-    "    source_table_id = \"CY_FDM_BUILDER_TESTS.test_table_3\",\n",
+    "    source_table_id = \"CB_FDM_BUILDER_TESTS.test_table_3\",\n",
     "    dataset_id = DATASET_ID\n",
     ")\n",
     "test_table_3.copy_table_to_dataset()\n",


### PR DESCRIPTION
The current classes and examples still reference CY_ tables. This PR amends these occurences to CB_